### PR TITLE
Update README to point to updated link on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Specifying an R environment with a runtime.txt file
 
-Jupyter+R: [![Binder](http://mybinder.org/badge.svg)](http://beta.mybinder.org/v2/gh/binder-examples/rstudio/master?filepath=index.ipynb)
+Jupyter+R: [![Binder](http://mybinder.org/badge.svg)](http://beta.mybinder.org/v2/gh/binder-examples/r/master?filepath=index.ipynb)
 
-RStudio: [![Binder](http://mybinder.org/badge.svg)](http://beta.mybinder.org/v2/gh/binder-examples/rstudio/master?urlpath=rstudio)
+RStudio: [![Binder](http://mybinder.org/badge.svg)](http://beta.mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio)
 
 Binder supports using R + RStudio, with libraries pinned to a specific 
 snapshot on [MRAN](https://mran.microsoft.com/documents/rro/reproducibility).


### PR DESCRIPTION
- Replace "rstudio" in URL for Binder with "r"
- Reflects chante in repo name
- Tested to ensure that Binder builds from the new URLs

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>