### PR TITLE
Replace ggplot2 with tidyverse in install.R

### DIFF
--- a/install.R
+++ b/install.R
@@ -1,2 +1,2 @@
-install.packages("ggplot2")
+install.packages("tidyverse")
 install.packages("rmarkdown")


### PR DESCRIPTION
Install all of [`tidyverse`](https://www.tidyverse.org/) instead of just `ggplot2`, for a repo bootstrapped for data-science using R.

Couldn't test the `.ipynb` file with the change as I kept getting assorted errors. But `ggplot2` is part of `tidyverse`, so it should work in principle.

Signed-off-by: Achintya Rao <achintya.rao@cern.ch>