### PR TITLE
Added explanation to index.ipynb

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "R Code pulled from https://www.statmethods.net/advgraphs/ggplot2.html"
+    "File serving the purpose of creating a Binder repo (https://github.com/binder-examples/r). R Code pulled from https://www.statmethods.net/advgraphs/ggplot2.html"
    ]
   },
   {


### PR DESCRIPTION
Added explanation to index.ipynb: 'File serving the purpose of creating a Binder repo (https://github.com/binder-examples/r).'