### PR TITLE
Reword reference to r-conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RShiny: [![Binder](http://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/g
 Binder supports using R and RStudio, with libraries pinned to a specific 
 snapshot on [MRAN](https://mran.microsoft.com/documents/rro/reproducibility).
 
-**Note:** We recommend to follow [r-conda](https://github.com/binder-examples/r-conda) instead. Especially if you want to use a specific version of R or need faster build times.
+**Note:** Check out [r-conda](https://github.com/binder-examples/r-conda) as well, if you prefer using conda to manage your packages.
 
 **Note:** Another alternative is to use the [holepunch package for R](https://karthik.github.io/holepunch/articles/getting_started.html).
 


### PR DESCRIPTION
Recent R work on repo2docker has provided faster builds (thanks to binary packages)
as well as all of CRAN. This PR keeps the alternative pointed but rewords it to be slightly
less aggressive.